### PR TITLE
fix: Focus on modal input

### DIFF
--- a/src/Modal/index.tsx
+++ b/src/Modal/index.tsx
@@ -31,6 +31,7 @@ export const Keystroke = styled.span`
 interface Props {
   isOpen: boolean
   onClose: () => void
+  onAfterOpen?: () => void
   title: string
   additionalKeystrokes?: React.ReactNode
 }
@@ -38,6 +39,7 @@ interface Props {
 const Modal: FunctionComponent<Props> = ({
   isOpen,
   onClose,
+  onAfterOpen,
   title,
   children,
   additionalKeystrokes,
@@ -47,6 +49,7 @@ const Modal: FunctionComponent<Props> = ({
   return (
     <ReactModal
       isOpen={isOpen}
+      onAfterOpen={onAfterOpen}
       onRequestClose={onClose}
       style={{
         overlay: {

--- a/src/SubscriptionAddModal/index.tsx
+++ b/src/SubscriptionAddModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useRef, useLayoutEffect, useState, useCallback } from "react"
+import React, { FunctionComponent, useRef, useState, useCallback } from "react"
 import styled from "styled-components"
 
 import Modal, { KeystrokeContainer, Keystroke } from "../Modal"
@@ -40,6 +40,8 @@ const SubscriptionAddModal: FunctionComponent<Props> = ({ isOpen, onClose, onAdd
   const [path, setPath] = useState("")
   const inputRef = useRef<HTMLInputElement>(null)
 
+  const handleAfterOpen = () => inputRef.current && inputRef.current.focus()
+
   const handleClose = useCallback(() => {
     setPath("")
     onClose()
@@ -56,17 +58,12 @@ const SubscriptionAddModal: FunctionComponent<Props> = ({ isOpen, onClose, onAdd
     }
   }, [path])
 
-  useLayoutEffect(() => {
-    if (isOpen && inputRef.current) {
-      inputRef.current.focus()
-    }
-  }, [isOpen, inputRef.current])
-
   return (
     <Modal
       title="Add Subscription"
       isOpen={isOpen}
       onClose={handleClose}
+      onAfterOpen={handleAfterOpen}
       additionalKeystrokes={
         <KeystrokeContainer>
           <Keystroke>ENTER</Keystroke> Subscribe


### PR DESCRIPTION
It seems the focus on input is invalidated and moved to the modal itself after `useLayoutEffect`, so let's utilize `onAfterOpen`.


![onfocus](https://user-images.githubusercontent.com/8325407/69368149-e99de900-0cdc-11ea-8031-19129305bf1b.gif)
