### PR TITLE
Fix: header shadow overlapping Flipper UI

### DIFF
--- a/src/Header/index.tsx
+++ b/src/Header/index.tsx
@@ -8,7 +8,7 @@ const Container = styled.div`
   background-color: ${props => props.theme.backgroundSubtleLight};
   border-bottom: 1px solid ${props => props.theme.chromeLine};
   color: ${props => props.theme.foregroundDark};
-  box-shadow: 0 0 30px ${props => props.theme.glow};
+  box-shadow: 0 30px 30px -25px ${props => props.theme.glow};
 `
 
 interface ContentContainerProps {


### PR DESCRIPTION
Since the Flipper plugin places on top of Flipper's left sidebar(Probably need to make some changes to correct the z-index of Flipper UI itself), the header shadow of Reactotron overlaps. This PR fixes it - Note that the shadow doesn't cover the same width of the header but it looks good enough for me.

### - Current beta
![image](https://user-images.githubusercontent.com/8325407/69455140-14ef0980-0dab-11ea-9a78-bb55e31da0ca.png)

### - Above: current beta, below: fix
![image](https://user-images.githubusercontent.com/8325407/69455131-0ef92880-0dab-11ea-9efd-4992fa0aa94f.png)
